### PR TITLE
Preserve user message text when building email

### DIFF
--- a/mailer.php
+++ b/mailer.php
@@ -5,9 +5,9 @@ $myemail = "haighscarpets@outlook.com";
 /* Check all form inputs using check_input function */
 $name = check_input($_POST['inputName'], "Your Name");
 $email = check_input($_POST['inputEmail'], "Your E-mail Address");
-$Subject = check_input($_POST['inputSubject'], "Subject");
+$userSubject = check_input($_POST['inputSubject'], "Subject");
 $Telephone = check_input($_POST['inputTelephone'], "Telephone");
-$message = check_input($_POST['inputMessage'], "Your Message");
+$userMessage = check_input($_POST['inputMessage'], "Your Message");
 
 /* If e-mail is not valid show error message */
 if (!preg_match("/([\w\-]+\@[\w\-]+\.[\w\-]+)/", $email))
@@ -16,24 +16,24 @@ show_error("Invalid e-mail address");
 }
 /* Let's prepare the message for the e-mail */
 
-$Subject = "Someone has sent you a message - via Haighs Carpets Website";
+$emailSubject = "Someone has sent you a message - via Haighs Carpets Website";
 
-$message = "
+$emailBody = "
 
 Someone has sent you a message using Haighs Carpets Website contact form:
 
 Name: $name
 Email: $email
 Telephone: $Telephone
-Subject: $Subject
+Subject: $userSubject
 
 Message:
-$message
+$userMessage
 
 ";
 
 /* Send the message using mail() function */
-mail($myemail, $Subject, $message);
+mail($myemail, $emailSubject, $emailBody);
 
 /* Redirect visitor to the thank you page */
 header('Location: http://www.haighscarpets.com/thankyou.html');


### PR DESCRIPTION
## Summary
- keep the sanitized visitor message in its own variable when reading the form submission
- build a dedicated `$emailBody` string that interpolates the visitor's subject and message text
- send the composed email body while leaving the fixed email subject header untouched

## Testing
- not run (mail() requires an email-capable environment)


------
https://chatgpt.com/codex/tasks/task_e_68ce6ebdb6ac832683c9a4254498613d