### PR TITLE
Update footer copyright to 2025

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -226,7 +226,7 @@
             <a href="https://plus.google.com/110276580442793744635/about?gl=GB&hl=en-GB"><i class="fa fa-google-plus-square fa-4x google"></i></a>
           </div>
       </div><!-- /.row -->
-        <div class="text-center"><p>&copy; Haigh's Carpets 2019</p></div>
+        <div class="text-center"><p>&copy; Haigh's Carpets 2025</p></div>
       </footer>
 
     </div><!-- /.container -->

--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@
             <a href="https://plus.google.com/110276580442793744635/about?gl=GB&hl=en-GB"><i class="fa fa-google-plus-square fa-4x google"></i></a>
           </div>
       </div><!-- /.row -->
-        <div class="text-center"><p>&copy; Haigh's Carpets 2019</p></div>
+        <div class="text-center"><p>&copy; Haigh's Carpets 2025</p></div>
       </footer>
 
     </div><!-- /.container -->

--- a/map.html
+++ b/map.html
@@ -172,7 +172,7 @@
       <div class="container">
       <footer>
       <hr>
-        <div class="text-center"><p>&copy; Haigh's Carpets 2019</p></div>
+        <div class="text-center"><p>&copy; Haigh's Carpets 2025</p></div>
       </footer>
 
     </div><!-- /.container -->

--- a/products.html
+++ b/products.html
@@ -191,7 +191,7 @@
             <a href="https://plus.google.com/110276580442793744635/about?gl=GB&hl=en-GB"><i class="fa fa-google-plus-square fa-4x google"></i></a>
           </div>
       </div><!-- /.row -->
-        <div class="text-center"><p>&copy; Haigh's Carpets 2019</p></div>
+        <div class="text-center"><p>&copy; Haigh's Carpets 2025</p></div>
       </footer>
 
     </div><!-- /.container -->

--- a/thankyou.html
+++ b/thankyou.html
@@ -186,7 +186,7 @@
             <a href="https://plus.google.com/110276580442793744635/about?gl=GB&hl=en-GB"><i class="fa fa-google-plus-square fa-4x google"></i></a>
           </div>
       </div><!-- /.row -->
-        <div class="text-center"><p>&copy; Haigh's Carpets 2019</p></div>
+        <div class="text-center"><p>&copy; Haigh's Carpets 2025</p></div>
       </footer>
 
     </div><!-- /.container -->


### PR DESCRIPTION
## Summary
- update the footer copyright year to 2025 across the public site pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce6f05e3708326a1c51eb3a5b8f054